### PR TITLE
Ignore termios.error when hot-unplugging USB-Serial devices

### DIFF
--- a/serial_asyncio/__init__.py
+++ b/serial_asyncio/__init__.py
@@ -16,6 +16,7 @@ implementation. It should be possible to get that working though.
 """
 import asyncio
 import serial
+import termios
 
 
 __version__ = '0.1'
@@ -345,7 +346,12 @@ class SerialTransport(asyncio.Transport):
         assert self._closing
         assert not self._has_writer
         assert not self._has_reader
-        self._serial.flush()
+        try:
+            self._serial.flush()
+        except termios.error:
+            # ignore termios errors which may happen if the serial device was
+            # hot-unplugged.
+            pass
         try:
             self._protocol.connection_lost(exc)
         finally:


### PR DESCRIPTION
Hello!

I noticed that a termios.error(5, 'Input/Output') exception is raised calling serial.flush() when I unplug my usb-tty device and "connection_lost()" is never called on my SerialProtocol. Perhaps connection_lost() should still be called if serial.flush() raises an exception?

Thanks!