### PR TITLE
Converted connect and open_serial_connection to new-style coroutine definition.

### DIFF
--- a/serial_asyncio/__init__.py
+++ b/serial_asyncio/__init__.py
@@ -408,16 +408,14 @@ class SerialTransport(asyncio.Transport):
             self._loop = None
 
 
-@asyncio.coroutine
-def create_serial_connection(loop, protocol_factory, *args, **kwargs):
+async def create_serial_connection(loop, protocol_factory, *args, **kwargs):
     ser = serial.serial_for_url(*args, **kwargs)
     protocol = protocol_factory()
     transport = SerialTransport(loop, protocol, ser)
     return (transport, protocol)
 
 
-@asyncio.coroutine
-def open_serial_connection(*,
+async def open_serial_connection(*,
                            loop=None,
                            limit=asyncio.streams._DEFAULT_LIMIT,
                            **kwargs):
@@ -438,7 +436,7 @@ def open_serial_connection(*,
         loop = asyncio.get_event_loop()
     reader = asyncio.StreamReader(limit=limit, loop=loop)
     protocol = asyncio.StreamReaderProtocol(reader, loop=loop)
-    transport, _ = yield from create_serial_connection(
+    transport, _ = await create_serial_connection(
         loop=loop,
         protocol_factory=lambda: protocol,
         **kwargs)


### PR DESCRIPTION
As the old `@asyncio.coroutine` decorator is deprecated, this converts the two functions to use the new `async def` syntax. The test code runs fine using the new syntax.