### PR TITLE
Use async def syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ language: python
 cache: pip
 
 python:
-  - 3.4
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
 
 install:
   - pip install -r requirements-travis.txt

--- a/serial_asyncio/__init__.py
+++ b/serial_asyncio/__init__.py
@@ -10,7 +10,7 @@
 """\
 Support asyncio with serial ports. EXPERIMENTAL
 
-Posix platforms only, Python 3.4+ only.
+Posix platforms only, Python 3.5+ only.
 
 Windows event loops can not wait for serial ports with the current
 implementation. It should be possible to get that working though.
@@ -408,16 +408,14 @@ class SerialTransport(asyncio.Transport):
             self._loop = None
 
 
-@asyncio.coroutine
-def create_serial_connection(loop, protocol_factory, *args, **kwargs):
+async def create_serial_connection(loop, protocol_factory, *args, **kwargs):
     ser = serial.serial_for_url(*args, **kwargs)
     protocol = protocol_factory()
     transport = SerialTransport(loop, protocol, ser)
     return (transport, protocol)
 
 
-@asyncio.coroutine
-def open_serial_connection(*,
+async def open_serial_connection(*,
                            loop=None,
                            limit=asyncio.streams._DEFAULT_LIMIT,
                            **kwargs):
@@ -438,7 +436,7 @@ def open_serial_connection(*,
         loop = asyncio.get_event_loop()
     reader = asyncio.StreamReader(limit=limit, loop=loop)
     protocol = asyncio.StreamReaderProtocol(reader, loop=loop)
-    transport, _ = yield from create_serial_connection(
+    transport, _ = await create_serial_connection(
         loop=loop,
         protocol_factory=lambda: protocol,
         **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ import os
 import re
 import sys
 
-if sys.version_info < (3, 4):
-    raise RuntimeError("pyserial-asyncio requires at least Python 3.4")
+if sys.version_info < (3, 5):
+    raise RuntimeError("pyserial-asyncio requires at least Python 3.5")
 
 from setuptools import setup
 
@@ -76,10 +76,10 @@ Async I/O extension package for the Python Serial Port Extension for OSX, Linux,
         'Operating System :: MacOS :: MacOS X',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Communications',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
Switch to `async def` syntax for coroutine definition, since `@asyncio.coroutine` decorator is deprecated in Python 3.8

Impact: makes library incompatible with Python 3.4 which is [EOL](https://www.python.org/downloads/release/python-3410/)

Fixes #54 
