### PR TITLE
fix multiple writers race on windows

### DIFF
--- a/serial_asyncio/__init__.py
+++ b/serial_asyncio/__init__.py
@@ -57,6 +57,7 @@ class SerialTransport(asyncio.Transport):
         self._has_reader = False
         self._has_writer = False
         self._poll_wait_time = 0.0005
+        self._max_out_waiting = 1024
 
         # XXX how to support url handlers too
 
@@ -303,7 +304,7 @@ class SerialTransport(asyncio.Transport):
         def _poll_write(self):
             if self._has_writer and not self._closing:
                 self._has_writer = self._loop.call_later(self._poll_wait_time, self._poll_write)
-                if self.serial.out_waiting:
+                if self.serial.out_waiting < self._max_out_waiting:
                     self._write_ready()
 
         def _ensure_writer(self):

--- a/serial_asyncio/__init__.py
+++ b/serial_asyncio/__init__.py
@@ -309,7 +309,7 @@ class SerialTransport(asyncio.Transport):
 
         def _ensure_writer(self):
             if not self._has_writer and not self._closing:
-                self._has_writer = self._loop.call_later(self._poll_wait_time, self._poll_write)
+                self._has_writer = self._loop.call_soon(self._poll_write)
 
         def _remove_writer(self):
             if self._has_writer:


### PR DESCRIPTION
We found a race between two poll_writers which can happen in our test harness. I guess this will also happen on real windows machines. This will trigger the assert `Write buffer should not be empty` in `_write_ready`. Therefore, might have to backport it.