### PR TITLE
Executor fix: use a callback in run_in_executor

### DIFF
--- a/serial_asyncio/__init__.py
+++ b/serial_asyncio/__init__.py
@@ -19,6 +19,7 @@ import asyncio
 import os
 
 import serial
+from functools import partial
 
 try:
     import termios
@@ -446,7 +447,8 @@ async def create_serial_connection(loop, protocol_factory, *args, **kwargs):
 
     Any additional arguments will be forwarded to the Serial constructor.
     """
-    serial_instance = await loop.run_in_executor(None, serial.serial_for_url, *args, **kwargs)
+    callback = partial(serial.serial_for_url, *args, **kwargs)
+    serial_instance = await loop.run_in_executor(None, callback)
     transport, protocol = await connection_for_serial(loop, protocol_factory, serial_instance)
     return transport, protocol
 


### PR DESCRIPTION
As stated in:
https://github.com/pyserial/pyserial-asyncio/pull/82
last commit threw error with the following stack trace:
```
Logger: homeassistant.config_entries
Source: components/zha/core/gateway.py:182
First occurred: 16:12:26 (1 occurrences)
Last logged: 16:12:26

Error setting up entry socket://[192.168.1.12:2001](http://192.168.1.12:2001/) for zha
Traceback (most recent call last):
 File "/usr/src/homeassistant/homeassistant/config_entries.py", line 335, in async_setup
   result = await component.async_setup_entry(hass, self)
 File "/usr/src/homeassistant/homeassistant/components/zha/__init__.py", line 102, in async_setup_entry
   await zha_gateway.async_initialize()
 File "/usr/src/homeassistant/homeassistant/components/zha/core/gateway.py", line 182, in async_initialize
   self.application_controller = await app_controller_cls.new(
 File "/usr/local/lib/python3.9/site-packages/zigpy/application.py", line 69, in new
   await app.startup(auto_form)
 File "/usr/local/lib/python3.9/site-packages/bellows/zigbee/application.py", line 132, in startup
   self._ezsp = await bellows.ezsp.EZSP.initialize(self.config)
 File "/usr/local/lib/python3.9/site-packages/bellows/ezsp/__init__.py", line 82, in initialize
   await ezsp.connect()
 File "/usr/local/lib/python3.9/site-packages/bellows/ezsp/__init__.py", line 92, in connect
   self._gw = await bellows.uart.connect(self._config, self)
 File "/usr/local/lib/python3.9/site-packages/bellows/uart.py", line 363, in connect
   protocol, connection_done = await thread.run_coroutine_threadsafe(
 File "/usr/local/lib/python3.9/site-packages/bellows/uart.py", line 340, in _connect
   transport, protocol = await serial_asyncio.create_serial_connection(
 File "/usr/local/lib/python3.9/site-packages/serial_asyncio/__init__.py", line 449, in create_serial_connection
   serial_instance = await loop.run_in_executor(None, serial.serial_for_url, *args, **kwargs)
TypeError: run_in_executor() got an unexpected keyword argument 'url'
```

The fix will use the correct syntax and hopefully solve the problem in my Home Assistant setup (sometimes HA looses connection with ZHA on eszp protocol via socket).