### PR TITLE
tests: support windows

### DIFF
--- a/test/test_asyncio.py
+++ b/test/test_asyncio.py
@@ -25,10 +25,14 @@ HOST = '127.0.0.1'
 _PORT = 8888
 
 # on which port should the tests be performed:
-PORT = 'socket://%s:%s' % (HOST, _PORT)
+if os.name == "nt":
+    # these ports can be created by com0com-2.2.2.0
+    PORT = "COM20"
+    PORT2 = "COM21"
+else:
+    PORT = 'socket://%s:%s' % (HOST, _PORT)
 
 
-@unittest.skipIf(os.name != 'posix', "asyncio not supported on platform")
 class Test_asyncio(unittest.TestCase):
     """Test asyncio related functionality"""
 
@@ -88,6 +92,9 @@ class Test_asyncio(unittest.TestCase):
         if PORT.startswith('socket://'):
             coro = self.loop.create_server(Input, HOST, _PORT)
             self.loop.run_until_complete(coro)
+        else:
+            coro = serial_asyncio.create_serial_connection(self.loop, Input, PORT2)
+            self.loop.run_until_complete(coro)
 
         client = serial_asyncio.create_serial_connection(self.loop, Output, PORT)
         self.loop.run_until_complete(client)
@@ -103,6 +110,8 @@ if __name__ == '__main__':
     sys.stdout.write(__doc__)
     if len(sys.argv) > 1:
         PORT = sys.argv[1]
+    if len(sys.argv) > 2:
+        PORT2 = sys.argv[2]
     sys.stdout.write("Testing port: %r\n" % PORT)
     sys.argv[1:] = ['-v']
     # When this module is executed from the command-line, it runs all its tests


### PR DESCRIPTION
More of a question than a PR.  I have used the tool com0com-2.2.2.0 to create a pair of virtual com ports and do the loopback test provided in the tests module.  Tomorrow I will test with a pair of FTDI USB adapters and report back.

I am currently working on a project that must run under Windows - I would love to help get this fully supported.  I do not understand the note here:
https://github.com/pyserial/pyserial-asyncio/blob/6e1baf2f21b4607db6e44a6b42cf7ee876411356/serial_asyncio/__init__.py#L13-L16
Perhaps this is a good place for me to start?

Regarding flush (in regular pyserial), I'm not sure that I understand this comment:
https://github.com/pyserial/pyserial/blob/31fa4807d73ed4eb9891a88a15817b439c4eea2d/serial/serialwin32.py#L345-L349
```python3
    def flush(self):
        """\
        Flush of file like objects. In this case, wait until all data
        is written.
        """
        while self.out_waiting:
            time.sleep(0.05)
        # XXX could also use WaitCommEvent with mask EV_TXEMPTY, but it would
        # require overlapped IO and it's also only possible to set a single mask
        # on the port---
```
My reading of the [documentation](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-waitcommevent) is that `lpEvtMask` is a 16-bit value so we could listen to all, for example 0xffff and in this function just mask for 0x0004 to check if the buffer is empty.  I don't have much experience with these Windows APIs but my hope would be that `WaitCommEvent` blocks until an event occurs and that it would avoid the busy loop altogether.

Regardless of the number of events listened for it would look something like:
```python3
while p_lpEvtMask & EV_TXEMPTY == 0:
    success = win32.WaitCommEvent(self._port_handle, p_lpEvtMask)
```

Very excited to learn more!