### PR TITLE
Run cleanup functions synchronously if the event loop is stopping

### DIFF
--- a/serial_asyncio/__init__.py
+++ b/serial_asyncio/__init__.py
@@ -395,6 +395,20 @@ class SerialTransport(asyncio.Transport):
         self._remove_writer()  # Pending buffered data will not be written
         self._loop.create_task(self._call_connection_lost(exc))
 
+    async def _try_to_run_in_executor(self, executor, func, *args):
+        """Runs `func` synchronously if the executor is stopped."""
+
+        try:
+            coro = self._loop.run_in_executor(executor, func, *args)
+        except RuntimeError:
+            # This error is seen only when the event loop is shutting down and the
+            # executor has already been shut down first. Since the cleanup methods are
+            # usually fast and the loop is stopping anyways, we have no choice but to
+            # run them synchronously.
+            return func(*args)
+        else:
+            return await coro
+
     async def _call_connection_lost(self, exc):
         """Close the connection.
 
@@ -405,7 +419,7 @@ class SerialTransport(asyncio.Transport):
         assert not self._has_writer
         assert not self._has_reader
         try:
-            await self._loop.run_in_executor(None, self._serial.flush)
+            await self._try_to_run_in_executor(None, self._serial.flush)
         except (serial.SerialException if os.name == "nt" else termios.error):
             # ignore serial errors which may happen if the serial device was
             # hot-unplugged.
@@ -415,7 +429,7 @@ class SerialTransport(asyncio.Transport):
             self._protocol.connection_lost(exc)
         finally:
             self._write_buffer.clear()
-            await self._loop.run_in_executor(None, self._serial.close)
+            await self._try_to_run_in_executor(None, self._serial.close)
             self._serial = None
             self._protocol = None
             self._loop = None


### PR DESCRIPTION
Functions called on connection loss can fail to run in the executor if the event loop is shutting down at the same time:

```Python
2022-08-24 19:07:05.408 MacBook.local asyncio ERROR Task exception was never retrieved
future: <Task finished name='Task-9' coro=<SerialTransport._call_connection_lost() done, defined at ~/Projects/pyserial-asyncio/serial_asyncio/__init__.py:398> exception=RuntimeError('cannot schedule new futures after interpreter shutdown')>
Traceback (most recent call last):
  File "~/Projects/pyserial-asyncio/serial_asyncio/__init__.py", line 408, in _call_connection_lost
    await self._loop.run_in_executor(None, self._serial.flush)
  File "/usr/local/Cellar/python@3.9/3.9.13_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 819, in run_in_executor
    executor.submit(func, *args), loop=self)
  File "/usr/local/Cellar/python@3.9/3.9.13_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/thread.py", line 169, in submit
    raise RuntimeError('cannot schedule new futures after '
RuntimeError: cannot schedule new futures after interpreter shutdown
```

I think it's better to call them synchronously and risk potentially stalling the nearly-stopped event loop than to not call them at all.