### PR TITLE
Use `loop.create_connection` instead of pyserial's `protocol_socket` for TCP

### DIFF
--- a/serial_asyncio/__init__.py
+++ b/serial_asyncio/__init__.py
@@ -19,6 +19,7 @@ import asyncio
 import os
 
 import serial
+from functools import partial
 
 try:
     import termios
@@ -446,7 +447,8 @@ async def create_serial_connection(loop, protocol_factory, *args, **kwargs):
 
     Any additional arguments will be forwarded to the Serial constructor.
     """
-    serial_instance = await loop.run_in_executor(None, serial.serial_for_url, *args, **kwargs)
+    callback = partial(serial.serial_for_url, *args, **kwargs)
+    serial_instance = await loop.run_in_executor(None, callback)
     transport, protocol = await connection_for_serial(loop, protocol_factory, serial_instance)
     return transport, protocol
 


### PR DESCRIPTION
This change speeds up serial communication over pyserial's `select()`-based `socket://` handler by 2-5× in real-world scenarios (33KB of packets in ~3000 RX/TX operations now takes 12s instead of 25s).

I've patched the returned transport to be API-compatible with `SerialTransport`, including `get_extra_info("socket")`.

---

To get `master` to actually run, I've included the commit from https://github.com/pyserial/pyserial-asyncio/pull/83.  If you'd like to merge that PR separately, I'll rebase against `master` instead.