### PR TITLE
serial.out_waiting do not always exist

### DIFF
--- a/serial_asyncio/__init__.py
+++ b/serial_asyncio/__init__.py
@@ -306,7 +306,9 @@ class SerialTransport(asyncio.Transport):
         def _poll_write(self):
             if self._has_writer and not self._closing:
                 self._has_writer = self._loop.call_later(self._poll_wait_time, self._poll_write)
-                if self.serial.out_waiting < self._max_out_waiting:
+                if not getattr(self.serial, "out_waiting", None):
+                    self._write_ready()
+                elif self.serial.out_waiting < self._max_out_waiting:
                     self._write_ready()
 
         def _ensure_writer(self):


### PR DESCRIPTION
A big hello from the https://github.com/riptideio/pymodbus project. We have been using pyserial and pyserial-asyncio for quite a while.

I have been trying to get rid of some asyncio problems for a while, and after some debugging, I found the problem to be in pyserial-asyncio/pyserial

When you create a connection with "socket://..." e.g. "socket://127.0.0.1:5020", self.serial in do not have the out_waiting property.

Added a simple test to check for the property, which will secure it works.