### PR TITLE
Add rfc2217 support

### DIFF
--- a/serial_asyncio/__init__.py
+++ b/serial_asyncio/__init__.py
@@ -319,7 +319,7 @@ class SerialTransport(asyncio.Transport):
     def _poll_write(self):
         if self._has_writer and not self._closing:
             self._has_writer = self._loop.call_later(self._poll_wait_time, self._poll_write)
-            if not self._serial.port.startswith("rfc2217") and self.serial.out_waiting < self._max_out_waiting:
+            if not hasattr(self.serial, "out_waiting") or self.serial.out_waiting < self._max_out_waiting:
                 self._write_ready()
 
     def _ensure_writer(self):

--- a/serial_asyncio/__init__.py
+++ b/serial_asyncio/__init__.py
@@ -65,7 +65,8 @@ class SerialTransport(asyncio.Transport):
 
         # Asynchronous I/O requires non-blocking devices
         self._serial.timeout = 0
-        self._serial.write_timeout = 0
+        if not self.serial.port.startswith("rfc2217"):
+            self._serial.write_timeout = 0
 
         # These two callbacks will be enqueued in a FIFO queue by asyncio
         loop.call_soon(protocol.connection_made, self)
@@ -284,60 +285,52 @@ class SerialTransport(asyncio.Transport):
             self._maybe_resume_protocol()
             assert self._has_writer
 
-    if os.name == "nt":
-        def _poll_read(self):
-            if self._has_reader and not self._closing:
-                try:
-                    self._has_reader = self._loop.call_later(self._poll_wait_time, self._poll_read)
-                    if self.serial.in_waiting:
-                        self._read_ready()
-                except serial.SerialException as exc:
-                    self._fatal_error(exc, 'Fatal write error on serial transport')
-
-        def _ensure_reader(self):
-            if not self._has_reader and not self._closing:
+    def _poll_read(self):
+        if self._has_reader and not self._closing:
+            try:
                 self._has_reader = self._loop.call_later(self._poll_wait_time, self._poll_read)
+                if self.serial.in_waiting:
+                    self._read_ready()
+            except serial.SerialException as exc:
+                self._fatal_error(exc, 'Fatal write error on serial transport')
 
-        def _remove_reader(self):
-            if self._has_reader:
-                self._has_reader.cancel()
-            self._has_reader = False
-
-        def _poll_write(self):
-            if self._has_writer and not self._closing:
-                self._has_writer = self._loop.call_later(self._poll_wait_time, self._poll_write)
-                if self.serial.out_waiting < self._max_out_waiting:
-                    self._write_ready()
-
-        def _ensure_writer(self):
-            if not self._has_writer and not self._closing:
-                self._has_writer = self._loop.call_soon(self._poll_write)
-
-        def _remove_writer(self):
-            if self._has_writer:
-                self._has_writer.cancel()
-            self._has_writer = False
-
-    else:
-        def _ensure_reader(self):
-            if (not self._has_reader) and (not self._closing):
+    def _ensure_reader(self):
+        if not self._has_reader and not self._closing:
+            if os.name == "nt" or self._serial.port.startswith("rfc2217"):
+                self._has_reader = self._loop.call_later(self._poll_wait_time, self._poll_read)
+            else:
                 self._loop.add_reader(self._serial.fileno(), self._read_ready)
                 self._has_reader = True
 
-        def _remove_reader(self):
-            if self._has_reader:
+    def _remove_reader(self):
+        if self._has_reader:
+            if os.name == "nt" or self._serial.port.startswith("rfc2217"):
+                self._has_reader.cancel()
+            else:
                 self._loop.remove_reader(self._serial.fileno())
-                self._has_reader = False
+        self._has_reader = False
 
-        def _ensure_writer(self):
-            if (not self._has_writer) and (not self._closing):
-                self._loop.add_writer(self._serial.fileno(), self._write_ready)
+    def _poll_write(self):
+        if self._has_writer and not self._closing:
+            self._has_writer = self._loop.call_later(self._poll_wait_time, self._poll_write)
+            if not self._serial.port.startswith("rfc2217") and self.serial.out_waiting < self._max_out_waiting:
+                self._write_ready()
+
+    def _ensure_writer(self):
+        if not self._has_writer and not self._closing:
+            if os.name == "nt" or self._serial.port.startswith("rfc2217"):
+                self._has_writer = self._loop.call_soon(self._poll_write)
+            else:
+                self._loop.add_writer(self.serial.fileno(), self._write_ready)
                 self._has_writer = True
 
-        def _remove_writer(self):
-            if self._has_writer:
+    def _remove_writer(self):
+        if self._has_writer:
+            if os.name == "nt" or self._serial.port.startswith("rfc2217"):
+                self._has_writer.cancel()
+            else:
                 self._loop.remove_writer(self._serial.fileno())
-                self._has_writer = False
+        self._has_writer = False
 
     def _set_write_buffer_limits(self, high=None, low=None):
         """Ensure consistent write-buffer limits."""


### PR DESCRIPTION
Solution to #46 - support for rfc2217/ser2net connections.

The polling approach from windows worked so far, but I needed the `self` attribute to distinguish the platform/protocol, so I merged the two solutions.