### PR TITLE
Implement `get_protocol` and `set_protocol`

### DIFF
--- a/serial_asyncio/__init__.py
+++ b/serial_asyncio/__init__.py
@@ -193,6 +193,14 @@ class SerialTransport(asyncio.Transport):
         """
         self._abort(None)
 
+    def get_protocol(self):
+        """Return the current protocol."""
+        return self._protocol
+
+    def set_protocol(self, protocol):
+        """Set a new protocol.""".
+        self._protocol = protocol
+
     def flush(self):
         """ clears output buffer and stops any more data being written
         """


### PR DESCRIPTION
These methods are not implemented by `BaseProtocol`: https://docs.python.org/3/library/asyncio-protocol.html#asyncio.BaseTransport.set_protocol. Not sure if more needs to be done to support protocol switching but this is all my use case requires.

As an aside, is pyserial-asyncio still maintained? There are quite a few outstanding PRs and while more than a couple have been merged, no release has been made since 2021.